### PR TITLE
feat: Agregar carga perezosa para imágenes en el editor personalizado…

### DIFF
--- a/src/components/CustomEditor/index.tsx
+++ b/src/components/CustomEditor/index.tsx
@@ -35,6 +35,9 @@ const CustomEditor: React.FC<CustomEditorProps> = ({
     height: height,
     menubar: false,
     plugins: ['link', 'fullscreen', 'help', 'save', 'emoticons'],
+    content_css: [
+      'bootstrap/dist/css/bootstrap.min.css',
+    ],
     toolbar:
       'undo redo | formatselect | bold italic forecolor backcolor | ' +
       'alignleft aligncenter alignright alignjustify | ' +


### PR DESCRIPTION
… y actualizar estilos del calendario de eventos

Agregar carga perezosa para imágenes en el editor personalizado y actualizar estilos del calendario de eventos. Se agregó la carga perezosa para las imágenes en el editor personalizado y se actualizaron los estilos del calendario de eventos. También se añadió la hoja de estilos de Bootstrap al contenido del editor.